### PR TITLE
fix: on logout no redirection to login

### DIFF
--- a/src/pages/logout/index.tsx
+++ b/src/pages/logout/index.tsx
@@ -15,7 +15,7 @@ const Logout = () => {
       <div>You are successfully logout!</div>
       <button
         className="py-1 px-4 m-5 bg-zinc-300 dark:bg-neutral-800 hover:dark:bg-neutral-700 hover:bg-zinc-400 rounded-lg"
-        onClick={() => router.back()}
+        onClick={() => router.push('/auth')}
       >
         Return
       </button>


### PR DESCRIPTION
# Description

On logout page when we click on return it does not return us to login page but instead return to previous url

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update